### PR TITLE
Added license

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,4 +8,5 @@
   , "dependencies": {}
   , "main": "index"
   , "engines": { "node": ">=0.4.0" }
+  , "license": "MIT"
 }


### PR DESCRIPTION
Having the license string in the package.json is needed for some automated packaging in other ecosystems like webjars.
